### PR TITLE
ISSUE #2 - Added optional encoding flag

### DIFF
--- a/subsync.js
+++ b/subsync.js
@@ -3,7 +3,9 @@
 var argv = require('optimist').
     demand(1).
     usage([
-           "usage: $0 <spec> [spec, ...] < input.srt > output.srt",
+           "usage: $0 <flags> <spec> [spec, ...] < input.srt > output.srt",
+           "  where <flags> could be:",
+           "    -e : Encoding [i.e: latin1]. Default is utf8.",
            "  where <spec> is <position>+<shift> or <position>-<shift>",
            "    position can be hh:mm:ss or @",
            "    shift is a number in seconds.",
@@ -47,8 +49,11 @@ function createShifter(specs) {
 }
 
 
+// Setting encoding. See https://github.com/spion/subsync/issues/2
+var encoding = argv.e ? argv.e : 'utf8';
+
 var sub = [];
-process.stdin.setEncoding('utf8');
+process.stdin.setEncoding(encoding);
 process.stdin.resume();
 process.stdin.on('data', function(d) {
     sub.push(d);


### PR DESCRIPTION
I added an optional flag for setting encoding. I'm from Argentina (Spanish is the official language) and there are some characters that are replaced with "?" if incorrect encoding is set.

<img width="785" alt="screen shot 2017-08-07 at 18 20 11" src="https://user-images.githubusercontent.com/972572/29046374-a65f0372-7b9d-11e7-8085-3692f3687a16.png">

using "-e" the script allows to set any of the supported encodings by node

<img width="862" alt="screen shot 2017-08-07 at 18 20 39" src="https://user-images.githubusercontent.com/972572/29046373-a63ae30c-7b9d-11e7-9edf-b6b3c434dfd2.png">